### PR TITLE
avoid opening a graphics device

### DIFF
--- a/R/qgraph.R
+++ b/R/qgraph.R
@@ -1304,9 +1304,11 @@ qgraph <- function( input, ... )
   #if (!filetype%in%c('pdf','png','jpg','jpeg','svg','R','eps','tiff')) warning(paste("File type",filetype,"is not supported")) 
   
   # Specify background:
-  if (is.null(background)){
+  if (is.null(background) && !DoNotPlot){
     background <- par("bg")
     if (background == "transparent") background <- "white"    
+  } else {
+    background <- "white"
   }
   if (isColor(bg)) background <- bg
   # Remove alpha:
@@ -1343,7 +1345,10 @@ qgraph <- function( input, ... )
   
   # par settings:
   #parOrig <- par(no.readonly=TRUE)
-  par(pty=pty)
+  if (!DoNotPlot)
+  {
+    par(pty=pty)
+  }
   
   if (!edgelist)
   {
@@ -2743,25 +2748,32 @@ qgraph <- function( input, ... )
   
   
   # Compute loopRotation:
-  for (i in seq_len(nNodes))
+  if (DoNotPlot)
   {
-    if (is.na(loopRotation[i]))
+    loopRotation[is.na(loopRotation)] <- 0
+  } 
+  else 
+  {
+    for (i in seq_len(nNodes))
     {
-      centX <- mean(layout[,1])
-      centY <- mean(layout[,2])
-      for (g in 1:length(groups))
+      if (is.na(loopRotation[i]))
       {
-        if (i%in%groups[[g]] & length(groups[[g]]) > 1)
+        centX <- mean(layout[,1])
+        centY <- mean(layout[,2])
+        for (g in 1:length(groups))
         {
-          centX <- mean(layout[groups[[g]],1])
-          centY <- mean(layout[groups[[g]],2])
+          if (i%in%groups[[g]] & length(groups[[g]]) > 1)
+          {
+            centX <- mean(layout[groups[[g]],1])
+            centY <- mean(layout[groups[[g]],2])
+          }
         }
-      }
-      loopRotation[i] <- atan2usr2in(layout[i,1]-centX,layout[i,2]-centY)
-      if (shape[i]=="square")
-      {
-        loopRotation[i] <- c(0,0.5*pi,pi,1.5*pi)[which.min(abs(c(0,0.5*pi,pi,1.5*pi)-loopRotation[i]%%(2*pi)))]
-      }
+        loopRotation[i] <- atan2usr2in(layout[i,1]-centX,layout[i,2]-centY)
+        if (shape[i]=="square")
+        {
+          loopRotation[i] <- c(0,0.5*pi,pi,1.5*pi)[which.min(abs(c(0,0.5*pi,pi,1.5*pi)-loopRotation[i]%%(2*pi)))]
+        }
+      } 
     } 
   } 
   


### PR DESCRIPTION
Hi Sacha,

For some reason, `qgraph(...)` always opens a graphics device in R if none are open. This doesn't really look necessary to me and it can kinda mess things up in JASP. So I made some small changes to avoid this whenever `DoNotPlot = TRUE`.

a minimal example:

```r
data(big5)
data(big5groups)

# close all graphics devices
graphics.off() 
# get current device
dev.cur()
#null device 
#          1
big5Graph <- qgraph(cor(big5),minimum=0.25,groups=big5groups,
                            legend=TRUE,borders=FALSE, title = "Big 5 correlations", 
                            DoNotPlot = TRUE)

dev.cur()
# Current development verion of qgraph returns:
#RStudioGD 
#        2 
# This branch returns:
#null device 
#          1

```

I wasn't quite sure what loopRotation is needed for, but I'm sure you can judge that better.

Cheers,
Don