### PR TITLE
Exclude estimation of standard errors in cor_auto function.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: qgraph
 Type: Package
 Title: Graph Plotting Methods, Psychometric Data Visualization and Graphical Model Estimation
-Version: 1.9.5
+Version: 1.9.5-2
 Authors@R: c(
   person("Sacha", "Epskamp", email = "mail@sachaepskamp.com",role = c("aut", "cre")),
   person("Giulio", "Costantini", role = c("aut")),

--- a/R/cor_auto.R
+++ b/R/cor_auto.R
@@ -81,9 +81,9 @@ cor_auto <- function(
     if(missing == "fiml"){
       
       #fiml needs ml, TRUE and fit to have estimation in object
-      lavobject <- suppressWarnings(lavaan::lavCor(data, missing = missing, se = "standard", meanstructure = TRUE, estimator = "ML", output = "fit"))
+      lavobject <- suppressWarnings(lavaan::lavCor(data, missing = missing, se = "none", meanstructure = TRUE, estimator = "ML", output = "fit"))
       #compute correlation matrix from covariance matrix
-      CorMat <- cov2cor(lavaan::inspect(lavobject, "est")$theta)
+      CorMat <- cov2cor(lavaan::inspect(lavobject, "cov.ov"))
       class(CorMat) <- "matrix"
     }
     else{


### PR DESCRIPTION
Our previous fix for handling missing values with maximum likelihood based estimation using lavaan included the estimation of standard errors. This is not necessary since they are not used further. Still, they take a lot of time, so it should be best to exclude their estimation.