### PR TITLE
Change random network generation method to 'fast.heur.simple'

### DIFF
--- a/R/centralityFunctions.R
+++ b/R/centralityFunctions.R
@@ -333,7 +333,7 @@ smallworldness<-function(x, B=1000, up=.995, lo=.005)
   
   #generate B rnd networks with the same degree distribution of A
   deg.dist<-igraph::degree(A, mode="all", loops=F)
-  rndA<-lapply(1:B, function(x)degree.sequence.game(deg.dist, method="simple.no.multiple"))
+  rndA<-lapply(1:B, function(x)degree.sequence.game(deg.dist, method = "fast.heur.simple"))
   # compute the average (global) clustering coefficient over the B random networks
   clustrnd<-sapply(rndA, transitivity, type="global", isolates="zero")
   clustrnd_m<-mean(clustrnd)

--- a/R/centralityFunctions.R
+++ b/R/centralityFunctions.R
@@ -333,7 +333,7 @@ smallworldness<-function(x, B=1000, up=.995, lo=.005)
   
   #generate B rnd networks with the same degree distribution of A
   deg.dist<-igraph::degree(A, mode="all", loops=F)
-  rndA<-lapply(1:B, function(x)degree.sequence.game(deg.dist, method = "fast.heur.simple"))
+  rndA<-lapply(1:B, function(x)sample_degseq(deg.dist, method = "fast.heur.simple"))
   # compute the average (global) clustering coefficient over the B random networks
   clustrnd<-sapply(rndA, transitivity, type="global", isolates="zero")
   clustrnd_m<-mean(clustrnd)


### PR DESCRIPTION
`smallworldness()` calls `igraph::degree.sequence.game(deg.dist, method = "simple.no.multiple")`, which hard-errors because the `"simple.no.multiple"` method value is defunct as of igraph 2.1.0.

This PR fixes this